### PR TITLE
Fix `wpscan` indirect dependencies warning on Linux

### DIFF
--- a/Formula/wpscan.rb
+++ b/Formula/wpscan.rb
@@ -19,6 +19,11 @@ class Wpscan < Formula
   depends_on "ruby" # Some gems require >= ruby 2.7
   depends_on "xz" # for liblzma
 
+  on_linux do
+    depends_on "libffi"
+    depends_on "zlib"
+  end
+
   # Runtime dependencies of wpscan
   # List with `gem install --explain wpscan`
 


### PR DESCRIPTION
Fix warning generated by `brew linkage --cached --test --strict neved4/tap/wpscan` on Linux:

Indirect dependencies with linkage:
  libffi
  zlib

https://github.com/Neved4/homebrew-tap/actions/runs/10439102890/job/28907255756#step:7:48