### PR TITLE
Add `ungoogled-chromium.rb` cask

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,0 +1,39 @@
+cask "eloston-chromium" do
+  arch arm: "arm64", intel: "x86-64"
+
+  version "129.0.6668.89-1.1"
+  sha256 arm:   "16c9c862041c85dbca20abc913092e617fc6208bd9f21c6d60c8c9646267251c",
+         intel: "59759a0305ad389513cbe285ba314dd2d49cd69f451fe3bbfab85a81a5d3a28c"
+
+  url "https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/download/#{version}/ungoogled-chromium_#{version}_#{arch}-macos.dmg",
+      verified: "github.com/ungoogled-software/ungoogled-chromium-macos/"
+  name "Ungoogled Chromium"
+  desc "Google Chromium, sans integration with Google"
+  homepage "https://ungoogled-software.github.io/"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:[.-]\d+)+)(?:[._-]#{arch})?(?:[._-]+?(\d+(?:\.\d+)*))?$/i)
+    strategy :github_latest do |json, regex|
+      match = json["tag_name"]&.match(regex)
+      next if match.blank?
+
+      match[1]
+    end
+  end
+
+  conflicts_with cask: [
+    "chromium",
+    "freesmug-chromium",
+  ]
+  depends_on macos: ">= :big_sur"
+
+  app "Chromium.app"
+
+  zap trash: [
+    "~/Library/Application Support/Chromium",
+    "~/Library/Caches/Chromium",
+    "~/Library/Preferences/org.chromium.Chromium.plist",
+    "~/Library/Saved Application State/org.chromium.Chromium.savedState",
+  ]
+end

--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -28,7 +28,7 @@ cask "eloston-chromium" do
   ]
   depends_on macos: ">= :big_sur"
 
-  app "Chromium.app"
+  app "Chromium.app", target: "Chromium Ungoogled.app"
 
   zap trash: [
     "~/Library/Application Support/Chromium",

--- a/Casks/ungoogled-chromium.rb
+++ b/Casks/ungoogled-chromium.rb
@@ -1,4 +1,4 @@
-cask "eloston-chromium" do
+cask "ungoogled-chromium" do
   arch arm: "arm64", intel: "x86-64"
 
   version "129.0.6668.89-1.1"

--- a/Casks/ungoogled-chromium.rb
+++ b/Casks/ungoogled-chromium.rb
@@ -22,10 +22,6 @@ cask "ungoogled-chromium" do
     end
   end
 
-  conflicts_with cask: [
-    "chromium",
-    "freesmug-chromium",
-  ]
   depends_on macos: ">= :big_sur"
 
   app "Chromium.app", target: "Ungoogled Chromium.app"

--- a/Casks/ungoogled-chromium.rb
+++ b/Casks/ungoogled-chromium.rb
@@ -28,7 +28,7 @@ cask "ungoogled-chromium" do
   ]
   depends_on macos: ">= :big_sur"
 
-  app "Chromium.app", target: "Chromium Ungoogled.app"
+  app "Chromium.app", target: "Ungoogled Chromium.app"
 
   zap trash: [
     "~/Library/Application Support/Chromium",

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Yet another matrix client for desktop.
 Execute commands as another user.
 - [nfov] [<kbd>typescript</kbd>]
 ASCII / ANSI art viewer.
+- [ungoogled-chromium] [<kbd>c++</kbd>]
+Google Chromium, sans integration with Google.
 - [volatility] [<kbd>python</kbd>]
 Advanced memory forensics framework.
 - [withjava] [<kbd>rust</kbd>]
@@ -74,6 +76,7 @@ Wrap commands in specific Java versions.
 [Cinny]: https://github.com/cinnyapp/cinny-desktop
 [doas]: https://github.com/slicer69/doas
 [nfov]: https://nrlquaker.github.io/nfov/
+[ungoogled-chromium]: https://github.com/ungoogled-software/ungoogled-chromium
 [volatility]: https://github.com/volatilityfoundation/volatility
 [withjava]: https://git.arielaw.ar/arisunz/with-java
 


### PR DESCRIPTION
From: [homebrew-cask/eloston-chromium.rb](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/e/eloston-chromium.rb)

Both work with `~/Library/Application Support/Chromium` and run fine with the same data folder.

This PR avoids name clashes by renaming it to `Chromium Ungoogled.app`.