### PR TITLE
Stop running tests on macOS 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-12, macos-13, macos-14, macos-15, ubuntu-latest]
+        os: [macos-13, macos-14, macos-15, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
Now that macOS 15 is out, Homebrew only officially provides support for macOS 13 and higher. Although our formulas will probably continue to work on older versions of macOS, we should probably save the CI time.