### PR TITLE
Add `chromium.rb` cask

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,0 +1,54 @@
+# typed: strict
+# frozen_string_literal: true
+
+cask "chromium" do
+  arch arm: "Mac_Arm", intel: "Mac"
+
+  version :latest
+  sha256 :no_check
+
+  url "https://download-chromium.appspot.com/dl/#{arch}?type=snapshots",
+      verified: "download-chromium.appspot.com/dl/"
+  name "Chromium"
+  desc "Free and open-source web browser"
+  homepage "https://www.chromium.org/Home"
+
+  conflicts_with cask: [
+    "eloston-chromium",
+    "freesmug-chromium",
+  ]
+  depends_on macos: ">= :big_sur"
+
+  app "chrome-mac/Chromium.app"
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/chromium.wrapper.sh"
+  binary shimscript, target: "chromium"
+
+  preflight do
+    File.write shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{appdir}/Chromium.app/Contents/MacOS/Chromium' "$@"
+    EOS
+  end
+
+  postflight do
+    dict = {
+      "LSEnvironment.GOOGLE_API_KEY"               => "AIzaSyCkfPOPZXDKNn8hhgu3JrA62wIgC93d44k",
+      "LSEnvironment.GOOGLE_DEFAULT_CLIENT_ID"     => "811574891467.apps.googleusercontent.com",
+      "LSEnvironment.GOOGLE_DEFAULT_CLIENT_SECRET" => "kdloedMFGdGla2P1zacGjAQh",
+    }
+
+    plist = "#{appdir}/Chromium.app/Contents/Info.plist"
+
+    dict.each do |key, val|
+      system("plutil -replace #{key} -string '#{val}' #{plist}")
+    end
+  end
+
+  zap trash: [
+    "~/Library/Application Support/Chromium",
+    "~/Library/Caches/Chromium",
+    "~/Library/Preferences/org.chromium.Chromium.plist",
+    "~/Library/Saved Application State/org.chromium.Chromium.savedState",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Go version, display different time zones from the tz database.
 Ada/SPARK package manager.
 - [babelfish] [<kbd>go</kbd>]
 Translate bash scripts to fish.
+- [Chromium] [<kbd>c++</kbd>]
+Chromium web browser, with API keys loaded.
 - [Cinny] [<kbd>javascript</kbd>] [<kbd>rust</kbd>]
 Yet another matrix client for desktop.
 - [doas] [<kbd>c</kbd>]


### PR DESCRIPTION
Regular Chromium but with API keys loaded from [Debian](https://salsa.debian.org/chromium-team/chromium/-/blob/master/debian/etc/apikeys?ref_type=heads).

Affords having to manually patch `Info.plist` on every upgrade.