### PR TITLE
Add version and livecheck to `chromium.rb`

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -4,14 +4,19 @@
 cask "chromium" do
   arch arm: "Mac_Arm", intel: "Mac"
 
-  version :latest
-  sha256 :no_check
+  version "134.0.6990.0,6990.0"
+  sha256 "751d1bfc0c8ccb989b115523abc8cc058460cb8688216cf9c114f51bd48643f8"
 
   url "https://download-chromium.appspot.com/dl/#{arch}?type=snapshots",
       verified: "download-chromium.appspot.com/dl/"
   name "Chromium"
   desc "Free and open-source web browser"
   homepage "https://www.chromium.org/Home"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
 
   conflicts_with cask: [
     "eloston-chromium",


### PR DESCRIPTION
## Describe your changes

Added version information and livecheck to Chromium. This will allow `brew upgrade` to update Chromium. The tradeoff is this will also result in 1 PR each day since [the autobump action runs every 24 hours](https://github.com/Neved4/homebrew-tap/blob/f01cf1a45f8f13c4ffc1f88135b663661922e3c5/.github/workflows/autobump.yml#L5) and Chromium releases many new versions each day.
