### PR TITLE
Add GHA to automatically warn about and close stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: 'Close stale PRs'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 14
+          stale-pr-message: 'This pull request has been marked as stale because it has been inactive for more than 14 days. Please update this pull request or it will be automatically closed in 14 days.'
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'work-in-progress'
+          days-before-close: 14
+          close-pr-message: 'This pull request has been automatically closed because it has been inactive. Please reopen if you still intend to submit this pull request.'


### PR DESCRIPTION
## Describe your changes

Add a GitHub action that runs once per day to automatically warn about and close stale PRs.
