### PR TITLE
Temporarily set sha256 to `:no_check` for some casks as workaround for Brew bug

### DIFF
--- a/Casks/chromium@stable.rb
+++ b/Casks/chromium@stable.rb
@@ -2,8 +2,7 @@ cask "chromium@stable" do
   arch arm: "MacOsArm64", intel: "MacOsx"
 
   version "2025.1.1"
-  sha256 arm:   "b48621e907e2c63ae1f384c17258b53f6c56c8f223a5f23bbc01bd0036f1efbb",
-         intel: "cf450eaa230057e09b53d8c99dbd7c321a72febd681602d2a145aea98cdec766"
+  sha256 :no_check
 
   url "https://portswigger-cdn.net/burp/releases/download?product=community&version=#{version}&type=#{arch}",
       verified: "portswigger-cdn.net/burp/releases/"

--- a/Casks/chromium@ungoogled.rb
+++ b/Casks/chromium@ungoogled.rb
@@ -2,8 +2,7 @@ cask "chromium@ungoogled" do
   arch arm: "arm64", intel: "x86_64"
 
   version "132.0.6834.110-1.1"
-  sha256 arm:   "7cdab8658cccff9a9a0a79ff961a95dd0efee234f9bd1a0e8a7ee297805ea37a",
-         intel: "bf71f36d27ed8139379f9303cabba4f125683e967585182cd2812958264058ad"
+  sha256 :no_check
 
   url "https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/download/#{version}/ungoogled-chromium_#{version}_#{arch}-macos.dmg",
       verified: "github.com/ungoogled-software/ungoogled-chromium-macos/"


### PR DESCRIPTION
Partly caused by our CI.