### PR TITLE
Convert actions from tagged versions to commit hashes

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Update Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@baf2b60c51fc1f8453c884b0c61052668a71bd1d
+        uses: dawidd6/action-homebrew-bump-formula@8d494330bce4434918392df134ad3db1167904db # v4
         with:
           token: ${{ secrets.HOMEBREW_TAP_GITHUB_API_TOKEN }}
           user_name: Neved4
@@ -20,7 +20,7 @@ jobs:
           force: true
           livecheck: true
       - name: Update Homebrew cask
-        uses: eugenesvk/action-homebrew-bump-cask@cc260684c6e41de1af9522a0f4dcb4f321a17f33
+        uses: eugenesvk/action-homebrew-bump-cask@cc260684c6e41de1af9522a0f4dcb4f321a17f33 # v3.8.4
         with:
           token: ${{ secrets.HOMEBREW_TAP_GITHUB_API_TOKEN }}
           tap: Neved4/homebrew-tap

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@65230870f9052190d1abac8192df9ffa5026fdf1 # no tagged version
 
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@65230870f9052190d1abac8192df9ffa5026fdf1 # no tagged version
 
       - name: Pull bottles
         env:
@@ -26,7 +26,7 @@ jobs:
         run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
-        uses: Homebrew/actions/git-try-push@master
+        uses: Homebrew/actions/git-try-push@65230870f9052190d1abac8192df9ffa5026fdf1 # no tagged version
         with:
           token: ${{ github.token }}
           branch: main

--- a/.github/workflows/require-pr-pull.yml
+++ b/.github/workflows/require-pr-pull.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
         with:
           filters: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-stale: 14
           stale-pr-message: 'This pull request has been marked as stale because it has been inactive for more than 14 days. Please update this pull request or it will be automatically closed in 14 days.'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@65230870f9052190d1abac8192df9ffa5026fdf1 # no tagged version
 
       - name: Cache Homebrew Bundler RubyGems
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bottles_${{ matrix.os }}
           path: '*.bottle.*'


### PR DESCRIPTION
Prevents action authors from modifying versions in the future without our knowledge. We need to setup Dependabot to automatically create PRs to bump these.