### PR TITLE
Add macOS 26 to CI, remove macOS 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-13, macos-14, macos-15, ubuntu-latest]
+        os: [macos-14, macos-15, macos-26, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
macOS 26 GHA image is currently in beta. macOS 13 GHA image is deprecated.

macOS 13 was our only version testing x86 so we'll be testing only on arm going forward.