### PR TITLE
Fix autobump and update workflow actions

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -15,7 +15,7 @@ jobs:
       HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || github.token }}
     steps:
       - name: Update Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@1446dca236b0440c6f02723a3f14f13be2c04ab0 # v7
+        uses: dawidd6/action-homebrew-bump-formula@a0e064e08103c01870c6d1b05168d1b726aab119 # v8
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN || github.token }}
           user_name: Neved4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@9926e3be887aa6c9523a027099bf5e882056f5c1 # 2026-03-12, no tagged version
+        uses: Homebrew/actions/setup-homebrew@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026-07-17, no tagged version
 
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@9926e3be887aa6c9523a027099bf5e882056f5c1 # 2026-03-12, no tagged version
+        uses: Homebrew/actions/git-user-config@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026-07-17, no tagged version
 
       - name: Pull bottles
         env:
@@ -26,7 +26,7 @@ jobs:
         run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
-        uses: Homebrew/actions/git-try-push@9926e3be887aa6c9523a027099bf5e882056f5c1 # 2026-03-12, no tagged version
+        uses: Homebrew/actions/git-try-push@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026-07-17, no tagged version
         with:
           token: ${{ github.token }}
           branch: main

--- a/.github/workflows/require-pr-pull.yml
+++ b/.github/workflows/require-pr-pull.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: changes
         with:
           filters: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           days-before-stale: 14
           stale-pr-message: 'This pull request has been marked as stale because it has been inactive for more than 14 days. Please update this pull request or it will be automatically closed in 14 days.'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,17 +16,17 @@ jobs:
         os: [macos-26, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         if: ${{ runner.os != 'Linux' }}
         with:
           xcode-version: "^26.1"
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@9926e3be887aa6c9523a027099bf5e882056f5c1 # 2026-03-12, no tagged version
+        uses: Homebrew/actions/setup-homebrew@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026-07-17, no tagged version
 
       - name: Cache Homebrew Bundler RubyGems
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bottles_${{ matrix.os }}
           path: '*.bottle.*'
@@ -68,6 +68,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Determine whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@afee1c1eac2a506084c274e9c02c8e0687b48d9e # v1.2.2
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
       with:
         jobs: ${{ toJSON(needs) }}

--- a/Formula/dnsenum2.rb
+++ b/Formula/dnsenum2.rb
@@ -71,7 +71,7 @@ class Dnsenum2 < Formula
   end
 
   def install
-    perl = Formula["perl"].opt_bin/"perl"
+    perl = formula_opt_bin("perl")/"perl"
 
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
     ENV["PERL_MM_USE_DEFAULT"] = "1"

--- a/Formula/htrace-sh.rb
+++ b/Formula/htrace-sh.rb
@@ -30,7 +30,7 @@ class HtraceSh < Formula
     libexec.install Dir["*"]
     (libexec/"bin/htrace.sh").chmod 0555
     env = {
-      PATH: "#{Formula["gnu-getopt"].opt_bin}:#{Formula["gnu-sed"].libexec}/gnubin:" \
+      PATH: "#{formula_opt_bin("gnu-getopt")}:#{Formula["gnu-sed"].libexec}/gnubin:" \
             "#{Formula["coreutils"].libexec}/gnubin:$PATH",
     }
     (bin/"htrace.sh").write_env_script libexec/"bin/htrace.sh", env

--- a/Formula/kamal.rb
+++ b/Formula/kamal.rb
@@ -134,7 +134,7 @@ class Kamal < Formula
   end
 
   def install
-    gem = Formula["ruby"].opt_bin/"gem"
+    gem = formula_opt_bin("ruby")/"gem"
     ENV["GEM_HOME"] = libexec
     ENV["GEM_PATH"] = libexec
 

--- a/Formula/mediawiki.rb
+++ b/Formula/mediawiki.rb
@@ -32,14 +32,14 @@ class Mediawiki < Formula
     pkgshare.install Dir["*"]
     lua_binaries = pkgshare/"extensions/Scribunto/includes/Engines/LuaStandalone/binaries"
     rm_r lua_binaries if lua_binaries.exist?
-    system Formula["composer"].opt_bin/"composer", "dump-autoload",
+    system formula_opt_bin("composer")/"composer", "dump-autoload",
       "--no-dev", "--optimize", "--working-dir=#{pkgshare}"
     build_apcu
     write_mediawiki_nginx_config
     write_mediawiki_server
     (bin/"mediawiki").write_env_script libexec/"mediawiki-server",
       MW_DATA_DIR:              var/"mediawiki",
-      MEDIAWIKI_NGINX:          Formula["nginx"].opt_bin/"nginx",
+      MEDIAWIKI_NGINX:          formula_opt_bin("nginx")/"nginx",
       MEDIAWIKI_NGINX_TEMPLATE: libexec/"mediawiki-nginx.conf.template"
   end
 
@@ -80,8 +80,8 @@ class Mediawiki < Formula
     resource("apcu").stage do
       source_dir = Dir["*"].find { |entry| (Pathname(entry)/"config.m4").exist? } || "."
       cd source_dir do
-        system Formula["php"].opt_bin/"phpize"
-        system "./configure", "--with-php-config=#{Formula["php"].opt_bin}/php-config"
+        system formula_opt_bin("php")/"phpize"
+        system "./configure", "--with-php-config=#{formula_opt_bin("php")}/php-config"
         system "make"
         (libexec/"extensions").install "modules/apcu.so"
       end
@@ -160,7 +160,7 @@ class Mediawiki < Formula
       pm = static
       pm.max_children = 2
       clear_env = no
-      env[PATH] = #{Formula["diffutils"].opt_bin}:/usr/bin:/bin:/usr/sbin:/sbin
+      env[PATH] = #{formula_opt_bin("diffutils")}:/usr/bin:/bin:/usr/sbin:/sbin
       catch_workers_output = yes
       EOF
       "${php_fpm_bin}" -F -y "${fpm_conf}" -d "extension=${apcu_ext}" &
@@ -190,7 +190,7 @@ class Mediawiki < Formula
 
     nginx_pid = fork do
       ENV["MW_DATA_DIR"] = data_dir.to_s
-      ENV["MEDIAWIKI_NGINX"] = Formula["nginx"].opt_bin/"nginx"
+      ENV["MEDIAWIKI_NGINX"] = formula_opt_bin("nginx")/"nginx"
       ENV["MEDIAWIKI_NGINX_TEMPLATE"] = libexec/"mediawiki-nginx.conf.template"
       ENV["MEDIAWIKI_FPM_PORT"] = fpm_port.to_s
       exec libexec/"mediawiki-server", port.to_s, "127.0.0.1"


### PR DESCRIPTION
Repairs Formula autobump under Homebrew 6 by updating the SHA-pinned bump action to v8, which explicitly trusts the target tap. Also refreshes all other workflow actions to their latest stable release commits (or current Homebrew/actions master commit), while retaining SHA pinning and existing workflow configuration.\n\nThe first CI pass exposed newly enforced FormulaPathMethods audits. The reported opt_bin calls are mechanically migrated to formula_opt_bin without changing URLs, checksums, dependencies, or public interfaces.