### PR TITLE
Handle formulae requiring manual autobump updates

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -25,6 +25,7 @@ jobs:
           force: true
           livecheck: true
       - name: Update Homebrew cask
+        if: ${{ always() }}
         uses: eugenesvk/action-homebrew-bump-cask@6b066272df85c164f0496877387ecc8d989a194f # v3.8.6
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN || github.token }}

--- a/Formula/alire.rb
+++ b/Formula/alire.rb
@@ -1,11 +1,11 @@
 class Alire < Formula
   desc "Ada/SPARK package manager"
   homepage "https://alire.ada.dev/"
-  url "https://github.com/alire-project/alire/releases/download/v2.1.0/alr-2.1.0-bin-x86_64-#{OS.mac? ? "macos" : "linux"}.zip"
+  url "https://github.com/alire-project/alire/releases/download/v2.1.1/alr-2.1.1-bin-x86_64-#{OS.mac? ? "macos" : "linux"}.zip"
   if OS.mac?
-    sha256 "67d3389833b936a56534b7ad2ea91164b18db40318571e904fc8ab41aca7acc8"
+    sha256 "d3e16cdfaf0cfb2da62853b79b62910189fdca9d5fddc5c3ac5974ffc7d9544b"
   elsif OS.linux?
-    sha256 "e3b32cb0afe981b23d1a68da77452cf81ee1d82de8ebaf01c5e233be8b463fbe"
+    sha256 "09c66bcd8c35dd4b97b72c3d9b76e44caa6964a2db35aba069f396f00f1f64c7"
   end
 
   bottle do

--- a/Formula/iozone.rb
+++ b/Formula/iozone.rb
@@ -6,6 +6,7 @@ class Iozone < Formula
   license :cannot_represent
 
   livecheck do
+    skip "Upstream lists 3.511, but its source archive returns HTTP 404"
     url "https://www.iozone.org/src/current/"
     regex(/href=.*?iozone[._-]?v?(\d+(?:[._]\d+)+)\.t/i)
     strategy :page_match do |page, regex|

--- a/Formula/iozone.rb
+++ b/Formula/iozone.rb
@@ -7,11 +7,6 @@ class Iozone < Formula
 
   livecheck do
     skip "Upstream lists 3.511, but its source archive returns HTTP 404"
-    url "https://www.iozone.org/src/current/"
-    regex(/href=.*?iozone[._-]?v?(\d+(?:[._]\d+)+)\.t/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match&.first&.tr("_", ".") }
-    end
   end
 
   bottle do

--- a/Formula/keyscan.rb
+++ b/Formula/keyscan.rb
@@ -4,8 +4,8 @@ class Keyscan < Formula
   desc "GitHub Gists scanner with LLM-based classification"
   homepage "https://github.com/kevinMEH/keyscan"
   url "https://github.com/kevinMEH/keyscan/archive/refs/heads/main.tar.gz"
-  version "0.0.0-20260101-c297a23"
-  sha256 "795016f7051049154a4b571be779b5204e640d1fa150671a10d9b42603b32436"
+  version "0.0.0-20260507-c309a27"
+  sha256 "04d6cfa6ef4f1b637b0395b87dc049d3c81f040a2f5eb3d884d5fa6ebb6eed31"
   license "GPL-3.0-only"
 
   livecheck do


### PR DESCRIPTION
Handles the three Formula cases that cannot be completed by brew bump-formula-pr automatically:\n\n- manually updates alire to 2.1.1 with independently verified macOS and Linux checksums; its OS-conditional checksum stanzas are unsupported by the generic bumper\n- manually updates keyscan to commit c309a27 with an independently verified checksum; its moving main.tar.gz URL cannot be rewritten by brew bump-formula-pr\n- marks iozone livecheck skipped while upstream lists 3.511 but returns HTTP 404 for the source archive\n- ensures the Cask step still runs if a future Formula bump reports an isolated failure\n\nNo autobump rerun will be dispatched until all currently generated PRs are closed.