### PR TITLE
Fix autobump handling for LoFloccus and Pear assets

### DIFF
--- a/Casks/lofloccus.rb
+++ b/Casks/lofloccus.rb
@@ -7,6 +7,18 @@ cask "lofloccus" do
   desc "Sync Floccus bookmarks to a local folder or any cloud service"
   homepage "https://github.com/TCB13/LoFloccus"
 
+  livecheck do
+    url "https://api.github.com/repos/TCB13/LoFloccus/releases"
+    strategy :json do |json|
+      json.filter_map do |release|
+        next if release["draft"] || release["prerelease"]
+        next unless release["assets"]&.any? { |asset| asset["name"]&.match?(/macOS\.zip\z/i) }
+
+        release["tag_name"]
+      end
+    end
+  end
+
   depends_on :macos
 
   app "LoFloccus.app"

--- a/Casks/pear.rb
+++ b/Casks/pear.rb
@@ -1,13 +1,13 @@
 cask "pear" do
   arch arm: "-arm64", intel: ""
 
-  version "3.11.0"
-  sha256 arm:          "a2d68bd80117ce376a08229f5cfb0a4570d98aba4e56af8040c725b22e856e0d",
-         intel:        "27f74b53c7c4dd8c77ce44d7c7d0f955cb083e5251701e6ca2b3781e85c4e373",
+  version "3.12.0"
+  sha256 arm:          "1266b1efdf3cd22276b989445ea14f0afd6bc751c26fc0983f24dd527be2f724",
+         intel:        "76e4a859cfbb777ca4383f83455a4ee01a8345356b86f0a91395b9e7dda6a863",
          arm64_linux:  "0", # workaround for brew bug https://github.com/orgs/Homebrew/discussions/6008, https://github.com/Homebrew/homebrew-cask/issues/205491
          x86_64_linux: "0"
 
-  url "https://github.com/pear-devs/pear-desktop/releases/download/v#{version}/YouTube-Music-3.11.0#{arch}.dmg"
+  url "https://github.com/pear-devs/pear-desktop/releases/download/v#{version}/YouTube-Music-#{version}#{arch}.dmg"
   name "Pear Desktop"
   desc "YouTube Music desktop app"
   homepage "https://github.com/pear-devs/pear-desktop"


### PR DESCRIPTION
Repairs the two Cask cases the autobump action could not safely rewrite:\n\n- LoFloccus livecheck now considers only stable releases that actually contain a macOS ZIP; 1.2.5 ships only a Windows asset, so the Cask correctly remains at 1.2.4\n- Pear is updated to 3.12.0 with independently verified arm64 and Intel DMG checksums, and its URL now interpolates the version in both the tag and filename\n\nBoth files pass brew style locally.