### PR TITLE
Audit and harden formulae, casks, and tap CI

### DIFF
--- a/.github/workflows/tap-health.yml
+++ b/.github/workflows/tap-health.yml
@@ -1,0 +1,34 @@
+name: Tap health
+
+on:
+  schedule:
+    - cron: "23 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  health:
+    strategy:
+      matrix:
+        os: [macos-26, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026-07-17, no tagged version
+
+      - name: Trust tap
+        run: brew trust --tap Neved4/homebrew-tap
+
+      - name: Read all Formulae and Casks
+        run: brew readall --aliases --os=all --arch=all
+
+      - name: Check style
+        run: brew style
+
+      - name: Livecheck Formulae
+        run: brew livecheck --formulae --resources --tap Neved4/tap
+
+      - name: Livecheck Casks
+        run: brew livecheck --casks --tap Neved4/tap
+
+      - name: Strict online audit
+        run: brew audit --strict --online --tap Neved4/tap

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,6 @@ on:
       - main
   pull_request:
 
-env:
-  HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
-
 jobs:
   test-bot:
     strategy:
@@ -24,6 +21,9 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026-07-17, no tagged version
+
+      - name: Trust tap
+        run: brew trust --tap Neved4/homebrew-tap
 
       - name: Cache Homebrew Bundler RubyGems
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/Casks/burp-browser.rb
+++ b/Casks/burp-browser.rb
@@ -11,20 +11,7 @@ cask "burp-browser" do
   homepage "https://portswigger.net/burp/"
 
   livecheck do
-    url "https://portswigger.net/burp/releases/data"
-    strategy :json do |json|
-      all_versions = json.dig("ResultSet", "Results")
-      next if all_versions.blank?
-
-      all_versions.filter_map do |item|
-        item["version"] if
-              item["releaseChannels"]&.include?("Stable") &&
-              item["categories"]&.include?("Community") &&
-              item["builds"]&.any? do |build|
-                build["BuildCategoryPlatform"] == arch.to_s
-              end
-      end
-    end
+    skip "No reliable way to identify downloadable Community releases"
   end
 
   conflicts_with cask: [

--- a/Casks/chromium@api.rb
+++ b/Casks/chromium@api.rb
@@ -14,7 +14,7 @@ cask "chromium@api" do
     "eloston-chromium",
     "freesmug-chromium",
   ]
-  depends_on macos: :big_sur
+  depends_on macos: :ventura
 
   app "chrome-mac/Chromium.app"
   shimscript = "#{staged_path}/chromium.wrapper.sh"

--- a/Casks/font-monego.rb
+++ b/Casks/font-monego.rb
@@ -2,7 +2,8 @@ cask "font-monego" do
   version "0.0.0,ad2acdcfc48277dabdededd3a46f1348f720d110"
   sha256 "62a0135b020858a024736b6b3415ae5f37240c31cca138b849f4a906e12c69da"
 
-  url "https://github.com/cseelus/monego/archive/refs/heads/#{version.csv.second}.tar.gz"
+  # A commit archive is intentional because upstream has no tagged releases.
+  url "https://github.com/cseelus/monego/archive/#{version.csv.second}.tar.gz?download=1"
   name "Monego"
   desc "Beloved Monaco monospaced font, recreated with bold and italic variants"
   homepage "https://github.com/cseelus/monego"

--- a/Casks/google-chrome-testing.rb
+++ b/Casks/google-chrome-testing.rb
@@ -20,7 +20,7 @@ cask "google-chrome-testing" do
 
   auto_updates false
   conflicts_with cask: "google-chrome"
-  depends_on macos: :big_sur
+  depends_on macos: :ventura
 
   app "chrome-mac-#{arch}/Google Chrome for Testing.app", target: "Google Chrome.app"
 

--- a/Casks/nfov-tmp.rb
+++ b/Casks/nfov-tmp.rb
@@ -7,6 +7,8 @@ cask "nfov-tmp" do
   desc "ASCII / ANSI art viewer"
   homepage "https://github.com/nrlquaker/nfov"
 
+  deprecate! date: "2026-07-21", because: :discontinued
+
   depends_on :macos
 
   app "nfov.app"

--- a/Casks/runtimebrowser.rb
+++ b/Casks/runtimebrowser.rb
@@ -12,6 +12,8 @@ cask "runtimebrowser" do
     skip "No tagged version available"
   end
 
+  disable! date: "2026-07-21", because: :discontinued
+
   depends_on :macos
 
   app "RuntimeBrowser.app"

--- a/Formula/dgen.rb
+++ b/Formula/dgen.rb
@@ -1,8 +1,11 @@
 class Dgen < Formula
   desc "Sega Genesis / Mega Drive emulator"
   homepage "https://dgen.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/dgen/dgen/1.33/dgen-sdl-1.33.tar.gz"
-  sha256 "99e2c06017c22873c77f88186ebcc09867244eb6e042c763bb094b02b8def61e"
+  url "https://git.code.sf.net/p/dgen/dgen.git",
+      tag:      "v1.33",
+      revision: "1c196e63d3e35704a97a2cef60def9df3c9fd1ce"
+
+  head "https://git.code.sf.net/p/dgen/dgen.git", branch: "master"
 
   bottle do
     root_url "https://github.com/Neved4/homebrew-tap/releases/download/dgen-1.33"
@@ -12,17 +15,16 @@ class Dgen < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "681f2fd2b8eb3deceac795a7e11d535df6fe7cb424cbeec4cc50779dd075d5ab"
   end
 
-  head do
-    url "https://git.code.sf.net/p/dgen/dgen.git", branch: "master"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-  end
-
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "libarchive"
   depends_on "sdl12-compat"
 
   def install
+    # Clang 7 and newer interpret adjacent string literals without whitespace as user-defined literals.
+    inreplace "main.cpp", '"DGen/SDL v"VER', '"DGen/SDL v" VER'
+    inreplace "main.cpp", '"DGen/SDL version "VER', '"DGen/SDL version " VER'
+
     args = %W[
       --disable-silent-rules
       --disable-dependency-tracking
@@ -30,7 +32,7 @@ class Dgen < Formula
       --prefix=#{prefix}
     ]
     args << "--disable-asm" if Hardware::CPU.arm?
-    system "./autogen.sh" if build.head?
+    system "./autogen.sh"
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/mediawiki.rb
+++ b/Formula/mediawiki.rb
@@ -24,8 +24,13 @@ class Mediawiki < Formula
   depends_on "php"
 
   resource "apcu" do
-    url "https://pecl.php.net/get/apcu-5.1.24.tgz"
-    sha256 "5c28a55b27082c69657e25b7ecf553e2cf6b74ec3fa77d6b76f4fb982e001e43"
+    url "https://pecl.php.net/get/apcu-5.1.28.tgz"
+    sha256 "ca9c1820810a168786f8048a4c3f8c9e3fd941407ad1553259fb2e30b5f057bf"
+
+    livecheck do
+      url "https://pecl.php.net/rest/r/apcu/latest.txt"
+      regex(/^v?(\d+(?:\.\d+)+)$/i)
+    end
   end
 
   def install

--- a/Formula/unarj.rb
+++ b/Formula/unarj.rb
@@ -20,6 +20,10 @@ class Unarj < Formula
   resource "testfile" do
     url "https://s3.amazonaws.com/ARJ/ARJ286.EXE"
     sha256 "e7823fe46fd971fe57e34eef3105fa365ded1cc4cc8295ca3240500f95841c1f"
+
+    livecheck do
+      skip "Fixed test fixture"
+    end
   end
 
   def install

--- a/Formula/withjava.rb
+++ b/Formula/withjava.rb
@@ -19,6 +19,8 @@ class Withjava < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "bb969f32f130c43194f37cc6216c93ceb21b869809b8c76299404b0188464af7"
   end
 
+  disable! date: "2026-07-21", because: :repo_removed
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
## Summary
- repair dgen Git-source builds and update MediaWiki APCu
- disable, deprecate, or explicitly skip unavailable and non-automatable packages
- correct Cask download and macOS metadata
- replace the tap-trust bypass with supported trust and add scheduled tap-health checks

## Verification
- brew style Formula Casks
- actionlint .github/workflows/*.yml
- targeted strict online audit (before the local Homebrew auto-update removed path-based audit)
- dgen source build and brew test
- mediawiki source rebuild and brew test; APCu 5.1.28 loads
- Monego commit archive checksum verified