### PR TITLE
Scope tap health checks to Neved4/tap

### DIFF
--- a/.github/workflows/tap-health.yml
+++ b/.github/workflows/tap-health.yml
@@ -19,10 +19,10 @@ jobs:
         run: brew trust --tap Neved4/homebrew-tap
 
       - name: Read all Formulae and Casks
-        run: brew readall --aliases --os=all --arch=all
+        run: brew readall --aliases --os=all --arch=all Neved4/tap
 
       - name: Check style
-        run: brew style
+        run: brew style Neved4/tap
 
       - name: Livecheck Formulae
         run: brew livecheck --formulae --resources --tap Neved4/tap


### PR DESCRIPTION
The macOS Homebrew setup includes third-party taps. Scope readall and style to this tap so unrelated invalid Formulae cannot fail tap health.

Found by manual dispatch of run 29860165137.