### PR TITLE
Skip unavailable disabled packages in tap health audit

### DIFF
--- a/.github/workflows/tap-health.yml
+++ b/.github/workflows/tap-health.yml
@@ -31,4 +31,14 @@ jobs:
         run: brew livecheck --casks --tap Neved4/tap
 
       - name: Strict online audit
-        run: brew audit --strict --online --tap Neved4/tap
+        run: |
+          packages=()
+          while IFS= read -r path; do
+            name="${path##*/}"
+            name="${name%.rb}"
+            case "$name" in
+              withjava|runtimebrowser) continue ;;
+            esac
+            packages+=("Neved4/tap/$name")
+          done < <(find Formula Casks -type f -name '*.rb' -print)
+          brew audit --strict --online "${packages[@]}"

--- a/Formula/applist.rb
+++ b/Formula/applist.rb
@@ -22,6 +22,6 @@ class Applist < Formula
 
   test do
     desired_output = "/System/Library/CoreServices/Finder.app"
-    assert_includes shell_output("#{bin}/applist").strip, desired_output
+    assert_includes shell_output(bin/"applist").strip, desired_output
   end
 end

--- a/Formula/center.rb
+++ b/Formula/center.rb
@@ -23,4 +23,14 @@ class Center < Formula
     system ENV.cc, "-O3", "center.c", "-o", "center"
     bin.install "center"
   end
+
+  test do
+    command = if OS.mac?
+      "script -q /dev/null #{bin}/center"
+    else
+      "script -q -c #{bin}/center /dev/null"
+    end
+    output = pipe_output(command, "Homebrew\n")
+    assert_match "Homebrew", output
+  end
 end

--- a/Formula/johnnybgoode.rb
+++ b/Formula/johnnybgoode.rb
@@ -20,8 +20,17 @@ class Johnnybgoode < Formula
     system "cargo", "install", *std_cargo_args
   end
 
-  # test do
-  #   desired_output = "No such file or directory"
-  #   assert_includes shell_output("#{bin}/johnnybgoode path 11.03 2>&1", 101).strip, desired_output
-  # end
+  test do
+    (testpath/"johnny-home").mkpath
+    (testpath/"config.yaml").write <<~YAML
+      johnnydecimal_home: #{testpath}/johnny-home
+      name_scheme: default
+      regex:
+    YAML
+
+    output = shell_output(
+      "JOHNNYBGOODE_CONFIG_PATH=#{testpath}/config.yaml #{bin}/johnnybgoode invalid 2>&1",
+    )
+    assert_match 'johnnybgoode: "invalid" is not a recognized command', output
+  end
 end

--- a/Formula/tmbackup.rb
+++ b/Formula/tmbackup.rb
@@ -21,4 +21,8 @@ class Tmbackup < Formula
     bin.write_exec_script libexec/"src/tmbackup.sh"
     bin.install_symlink "tmbackup.sh" => "tmbackup"
   end
+
+  test do
+    system "sh", "-n", bin/"tmbackup"
+  end
 end

--- a/Formula/tmexcludes.rb
+++ b/Formula/tmexcludes.rb
@@ -21,4 +21,8 @@ class Tmexcludes < Formula
     bin.write_exec_script libexec/"tmexcludes.sh"
     bin.install_symlink "tmexcludes.sh" => "tmexcludes"
   end
+
+  test do
+    assert_match "usage: tmexcludes <command>", shell_output("#{bin}/tmexcludes 2>&1", 1)
+  end
 end


### PR DESCRIPTION
Homebrew online audit still probes dead URLs after a definition is disabled. Exclude only withjava and runtimebrowser, whose unavailable upstreams are the reason they are disabled, while strictly auditing every installable Formula and Cask.

Found by tap-health run 29860807999.