### PR TITLE
Normalize tap health livecheck output

### DIFF
--- a/.github/workflows/tap-health.yml
+++ b/.github/workflows/tap-health.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Livecheck Formulae
         run: |
           set +e
-          output="$(brew livecheck --formulae --resources --tap Neved4/tap 2>&1)"
+          output="$(HOMEBREW_NO_COLOR=1 brew livecheck --formulae --resources --tap Neved4/tap 2>&1)"
           status=$?
           set -e
           printf '%s\n' "$output"


### PR DESCRIPTION
Disable Homebrew color codes only for the captured Formula livecheck output so the strict allowlist can match the two known GitHub API 403 failures without masking unexpected errors.

`brew style Neved4/tap` and `git diff --check` pass.