### PR TITLE
Fix tap health livecheck allowlist

### DIFF
--- a/.github/workflows/tap-health.yml
+++ b/.github/workflows/tap-health.yml
@@ -36,12 +36,13 @@ jobs:
           set -e
           printf '%s\n' "$output"
           if [[ $status -ne 0 ]]; then
-            errors="$(printf '%s\n' "$output" | sed -n 's/.*\(autorecon\|keyscan\): Unable to get versions.*/\1/p')"
-            unexpected="$(printf '%s\n' "$output" | grep 'Unable to get versions' | grep -Ev '(autorecon|keyscan): Unable to get versions' || true)"
+            errors="$(printf '%s\n' "$output" | grep 'Unable to get versions' || true)"
+            unexpected="$(printf '%s\n' "$errors" | grep -Ev '^(autorecon|keyscan): Unable to get versions$' || true)"
             if [[ -n "$unexpected" || -z "$errors" ]]; then
               exit "$status"
             fi
-            printf 'Known GitHub API rate-limit failure for: %s\n' "$(printf '%s\n' "$errors" | paste -sd, -)"
+            printf 'Known GitHub API rate-limit failures:\n%s\n' "$errors"
+            exit 0
           fi
 
       - name: Livecheck Casks


### PR DESCRIPTION
Use portable anchored `grep` matching for captured livecheck failures and explicitly return success when every failure is one of the two known GitHub API 403 cases. Unexpected or absent error lines still preserve the original failure status.

`brew style Neved4/tap` and `git diff --check` pass.