### PR TITLE
Accept prefixed tap health livecheck errors

### DIFF
--- a/.github/workflows/tap-health.yml
+++ b/.github/workflows/tap-health.yml
@@ -37,7 +37,7 @@ jobs:
           printf '%s\n' "$output"
           if [[ $status -ne 0 ]]; then
             errors="$(printf '%s\n' "$output" | grep 'Unable to get versions' || true)"
-            unexpected="$(printf '%s\n' "$errors" | grep -Ev '^(autorecon|keyscan): Unable to get versions$' || true)"
+            unexpected="$(printf '%s\n' "$errors" | grep -Ev '(autorecon|keyscan): Unable to get versions' || true)"
             if [[ -n "$unexpected" || -z "$errors" ]]; then
               exit "$status"
             fi


### PR DESCRIPTION
Homebrew may prefix captured failures with `Error:`. Match the two allowlisted formula errors anywhere on the line while retaining the exact formula names and message. The explicit success path remains limited to output containing only those failures.

The parser was exercised against prefixed errors, and `brew style Neved4/tap` plus `git diff --check` pass.