### PR TITLE
Scope strict cask audits to macOS

### DIFF
--- a/.github/workflows/tap-health.yml
+++ b/.github/workflows/tap-health.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Strict online audit
         run: |
           packages=()
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            roots=(Formula)
+          else
+            roots=(Formula Casks)
+          fi
           while IFS= read -r path; do
             name="${path##*/}"
             name="${name%.rb}"
@@ -58,5 +63,5 @@ jobs:
               withjava|runtimebrowser) continue ;;
             esac
             packages+=("Neved4/tap/$name")
-          done < <(find Formula Casks -type f -name '*.rb' -print)
+          done < <(find "${roots[@]}" -type f -name '*.rb' -print)
           brew audit --strict --online "${packages[@]}"


### PR DESCRIPTION
Linux lacks the macOS artifact tools (`plutil`, `hdiutil`) required by strict online Cask audits. Keep cross-platform Formula auditing, but include Casks only on the macOS matrix runner where their downloaded applications can actually be inspected.

`brew style Neved4/tap` and `git diff --check` pass.