### PR TITLE
withjava: restore 0.1.1 from crates.io

### DIFF
--- a/Formula/withjava.rb
+++ b/Formula/withjava.rb
@@ -1,25 +1,9 @@
 class Withjava < Formula
   desc "Wrap commands in specific Java versions"
-  homepage "https://git.arielaw.ar/arisunz/with-java"
-  url "https://git.arielaw.ar/arisunz/with-java/archive/d71ed0dde95887e4d305f5bd6fd2f0e50079e436.tar.gz"
-  version "0.1.0-d71ed0dde95887e4d305f5bd6fd2f0e50079e436"
-  sha256 "3243dc190b5171ad5332cef672c982d505ea37a6ed2a0e56262de4eba48ff3a2"
+  homepage "https://crates.io/crates/with-java"
+  url "https://static.crates.io/crates/with-java/with-java-0.1.1.crate"
+  sha256 "dff33c4cb192c645bb7b44c724001033a34d4e5b88375e77a29a1c4400300b42"
   license "GPL-3.0-or-later"
-  head "https://git.arielaw.ar/arisunz/with-java.git", branch: "main"
-
-  livecheck do
-    skip "No tagged version available"
-  end
-
-  bottle do
-    root_url "https://github.com/Neved4/homebrew-tap/releases/download/withjava-0.1.0-d71ed0dde95887e4d305f5bd6fd2f0e50079e436"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "2080409cbeb3890c4eeda79aae69c5c53b929bbc47a8e8aa0e7038b302b0d974"
-    sha256 cellar: :any_skip_relocation, ventura:      "ad46a3b6aa568cf48dba9a244b348cd5e74870cf74b1c97cbd434b04614fdb21"
-    sha256 cellar: :any_skip_relocation, monterey:     "302799d37d9fece35dd1c234ae87bdbea0e6c99f18692f4675fab5fe1e55eb86"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "bb969f32f130c43194f37cc6216c93ceb21b869809b8c76299404b0188464af7"
-  end
-
-  disable! date: "2026-07-21", because: :repo_removed
 
   depends_on "rust" => :build
 
@@ -28,7 +12,6 @@ class Withjava < Formula
   end
 
   test do
-    desired_output = "with-java #{version.major_minor_patch}"
-    assert_equal desired_output, shell_output("#{bin}/with-java --version").strip
+    assert_equal "with-java 0.1.1", shell_output("#{bin}/with-java --version").strip
   end
 end


### PR DESCRIPTION
## Summary
- replace the unreachable Git-hosted source with the crates.io `with-java` 0.1.1 archive
- remove the obsolete head, livecheck skip, disabled state, commit-derived version, and stale bottles
- assert the explicit 0.1.1 version in the formula test

## Validation
- verified archive SHA-256: `dff33c4cb192c645bb7b44c724001033a34d4e5b88375e77a29a1c4400300b42`
- `brew style Neved4/tap/withjava`
- `brew livecheck withjava` (`0.1.1 ==> 0.1.1`)
- `brew install --build-from-source withjava` on macOS ARM64
- `brew test withjava`
- `with-java --version` (`with-java 0.1.1`)
- `brew audit --strict --online withjava` was run, but crates.io returned HTTP 403 from its data-access policy for the mandated homepage URL
- uninstalled the temporary verification installation